### PR TITLE
Enable inter-container communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Target programs; server and client, are installed in ~/workspace/bin, which is s
 ## Execute a server
 
     $ server
-    Server running at address na+sm://6564-0
+    Server running at address ofi+tcp;ofi_rxm://192.168.10.11:36083
 
 ## Execute a client
 Specify the server address, key and value
 
-    $ client na+sm://6564-0 111 222
+    $ client 'ofi+tcp;ofi_rxm://192.168.10.11:36083' 111 222
 
 ## Login to other containers in a container
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ x-common:
     - seccomp:unconfined
     - apparmor:unconfined
   privileged: false
+  networks:
+    - mochi_net
   command: >
     bash -c "sudo service ssh restart && sleep infinity"
 
@@ -25,15 +27,35 @@ services:
     <<: *x-common
     hostname: c1
     container_name: c1
+    networks:
+      mochi_net:
+        ipv4_address: 192.168.10.11
   c2:
     <<: *x-common
     hostname: c2
     container_name: c2
+    networks:
+      mochi_net:
+        ipv4_address: 192.168.10.12
   c3:
     <<: *x-common
     hostname: c3
     container_name: c3
+    networks:
+      mochi_net:
+        ipv4_address: 192.168.10.13
   c4:
     <<: *x-common
     hostname: c4
     container_name: c4
+    networks:
+      mochi_net:
+        ipv4_address: 192.168.10.14
+
+networks:
+  mochi_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.10.0/24

--- a/sample/client.c
+++ b/sample/client.c
@@ -53,7 +53,7 @@ init(const char *server)
 {
 	hg_return_t ret;
 
-	env.mid = margo_init("na+sm", MARGO_CLIENT_MODE, 0, 0);
+	env.mid = margo_init("tcp", MARGO_CLIENT_MODE, 0, 0);
 	assert(env.mid);
 
 	ret = margo_addr_lookup(env.mid, server, &env.serv_addr);

--- a/sample/server.c
+++ b/sample/server.c
@@ -14,7 +14,7 @@ main(int argc, char *argv[])
 	size_t addr_str_size = sizeof(addr_str);
 	hg_addr_t my_address;
 
-	mid = margo_init("na+sm", MARGO_SERVER_MODE, 0, 0);
+	mid = margo_init("tcp", MARGO_SERVER_MODE, 0, 0);
 	assert(mid);
 
 	margo_addr_self(mid, &my_address);


### PR DESCRIPTION
The sample code uses the `na+sm` protocol to communicate.
The `na+sm` protocol uses shared memory to transport; we can not use this for inter-container communication.

In this case, it is better to use `tcp` on `ofi` plugin.
( Please refer to https://mercury-hpc.github.io/user/na/ for available protocols. )

In addition, this PR creates the custom network `mochi_net`; we can connect to containers using the assigned IPv4 address.

![Screenshot from 2022-09-30 21-39-00](https://user-images.githubusercontent.com/17472875/193272379-68dc960a-2fbc-4356-9aa0-7dbc2abfb644.png)



